### PR TITLE
fix: enable npm trusted publishing and fix hardlink conversion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
@@ -124,7 +124,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   release_pypi:
     name: Publish to PyPI
@@ -132,11 +132,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -164,6 +165,5 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -197,6 +197,9 @@
       "description": "Create js language bindings",
       "steps": [
         {
+          "spawn": "convert-hardlink"
+        },
+        {
           "exec": "jsii-pacmak -v --target js"
         }
       ]

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -18,9 +18,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
   ],
   releaseToNpm: true,
   packageName: 'cdk-iot-core-certificates-v3',
+  npmTrustedPublishing: true,
+  workflowNodeVersion: '24',
   publishToPypi: {
     distName: 'cdk-iot-core-certificates-v3',
     module: 'cdk_iot_core_certificates_v3',
+    trustedPublishing: true,
   },
   bundledDeps: ['@aws-sdk/client-iot', '@smithy/smithy-client', 'aws-lambda', '@types/aws-lambda'],
 });

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,9 +36,9 @@ project.projectBuild.testTask.exec(
 project.addTask('convert-hardlink', {
   exec: 'find . -type f -links +1 -exec cp -f {} {}.tmp \\; -exec mv {}.tmp {} \\;',
 });
-const publishTask = project.tasks.tryFind('release:npm');
+const packageJsTask = project.tasks.tryFind('package:js');
 const task = project.tasks.tryFind('convert-hardlink');
-if (publishTask && task) {
-  publishTask.prependSpawn(task);
+if (packageJsTask && task) {
+  packageJsTask.prependSpawn(task);
 }
 project.synth();


### PR DESCRIPTION
## Summary
- trust-publish ブランチの全変更をmainにマージ（npmTrustedPublishing, PyPI trusted publishing, Node.js 24, projen upgrade等）
- **npm公開失敗の根本原因を修正**: `convert-hardlink`タスクが存在しない`release:npm`タスクにprependされていたため、ハードリンク変換が実行されず`E415 Hard link is not allowed`エラーが発生していた。`package:js`タスクにprependするよう修正。

## Root Cause
`project.tasks.tryFind('release:npm')` は `null` を返すため、`convert-hardlink` が一度も実行されていなかった。正しくは `package:js` タスクの前に実行する必要がある。

## Test plan
- [ ] ビルドCIが通ること
- [ ] mainマージ後のリリースワークフローでnpm/PyPI両方が正常にパブリッシュされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)